### PR TITLE
Improve stow package selection handling

### DIFF
--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -37,10 +37,28 @@ while read -r line; do
 done < "$MANIFEST"
 
 if (( ${#PACKAGES[@]} )); then
-  echo "[*] Desstow: ${PACKAGES[*]}"
-  pushd "$DOTFILES/config" >/dev/null
-  stow -v -D -t "$HOME/.config" "${PACKAGES[@]}"
-  popd >/dev/null
+  EXISTING=()
+  MISSING=()
+  for pkg in "${PACKAGES[@]}"; do
+    if [[ -d "$DOTFILES/config/$pkg" ]]; then
+      EXISTING+=("$pkg")
+    else
+      MISSING+=("$pkg")
+    fi
+  done
+
+  if (( ${#MISSING[@]} )); then
+    echo "[*] Omitiendo paquetes ausentes: ${MISSING[*]}"
+  fi
+
+  if (( ${#EXISTING[@]} )); then
+    echo "[*] Desstow: ${EXISTING[*]}"
+    pushd "$DOTFILES/config" >/dev/null
+    stow -v -D -t "$HOME/.config" "${EXISTING[@]}"
+    popd >/dev/null
+  else
+    echo "[*] No hay paquetes de ~/.config para desstow."
+  fi
 fi
 
 # 2) Eliminar symlinks creados según manifest


### PR DESCRIPTION
## Summary
- add an optional `--packages` argument to `bootstrap.sh` and ignore missing config packages
- write the filtered package list into the manifest and warn when nothing will be stowed
- make `rollback.sh` gracefully skip absent packages during destow

## Testing
- bash -n scripts/bootstrap.sh
- bash -n scripts/rollback.sh

------
https://chatgpt.com/codex/tasks/task_e_68f7348e5e70832db190d5a38a4beb51