### PR TITLE
docs: align git hook docs with repo layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Formato: entradas fechadas (YYYY-MM-DD), estilo “Keep a Changelog” simplific
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2025-10-28 — Documentación alineada con git-hooks
+
+### Cambiado
+- `README.md`: se documenta la ruta real `git/git-hooks` y el uso de `~/.git-hooks` (enlazada por `bootstrap.sh`) para los hooks compartidos.
+- Verificación rápida actualizada (`test -x ~/.git-hooks/*`).
+
 ## 2025-10-27 — Modularización Bash, fixes y atajos
 
 ### Añadido

--- a/README.md
+++ b/README.md
@@ -297,17 +297,17 @@ sudo pacman -S --needed fzf fd ripgrep bat eza zoxide wl-clipboard xclip trash-c
 
 ## Hooks de Git (reproducibles)
 
-Instala hooks centralizados en `~/.config/git/hooks/` y apúntalos globalmente:
+Instala hooks centralizados en `~/.git-hooks/` (el bootstrap los enlaza ahí) y apúntalos globalmente:
 
 ```bash
-mkdir -p ~/.config/git/hooks
+mkdir -p ~/.git-hooks
 # Copiar los hooks del repo (ajusta la ruta de origen según tu estructura):
-cp -f ./git/hooks/pre-commit ~/.config/git/hooks/pre-commit
-cp -f ./git/hooks/commit-msg ~/.config/git/hooks/commit-msg
-chmod +x ~/.config/git/hooks/{pre-commit,commit-msg}
+cp -f ./git/git-hooks/pre-commit ~/.git-hooks/pre-commit
+cp -f ./git/git-hooks/commit-msg ~/.git-hooks/commit-msg
+chmod +x ~/.git-hooks/{pre-commit,commit-msg}
 
 # Usar ruta global para todos los repos
-git config --global core.hooksPath "$HOME/.config/git/hooks"
+git config --global core.hooksPath "$HOME/.git-hooks"
 ```
 
 **Qué hacen:**
@@ -332,8 +332,8 @@ type fo cdf rgf fkill cb gbr dlogs dsh bench >/dev/null
 
 # Hooks activos
 git config --global core.hooksPath
-test -x ~/.config/git/hooks/pre-commit
-test -x ~/.config/git/hooks/commit-msg
+test -x ~/.git-hooks/pre-commit
+test -x ~/.git-hooks/commit-msg
 ```
 
 **Pruebas de hooks:**


### PR DESCRIPTION
## Summary
- document the git/git-hooks directory and ~/.git-hooks target in the README instructions
- update the quick verification commands to match the new hook path
- record the documentation refresh in the changelog

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff95b35fdc832d877dfb942891733e