### PR TITLE
Add MIT license file and reference in README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Dotfiles Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ done
 
 ### Licencia
 
-MIT
+[MIT](LICENSE)
 
 ---
 
@@ -350,4 +350,4 @@ git commit --allow-empty -m "WIP prueba" || echo "OK: commit-msg bloqueó el men
 
 ### License
 
-MIT
+[MIT](LICENSE)


### PR DESCRIPTION
## Summary
- add an MIT license file matching the default GitHub template
- link the Spanish and English README sections to the new license file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ff988974bc832d886cebd26bfed45a