### PR TITLE
Fix trash dependency check

### DIFF
--- a/bash/bash_lib/core.sh
+++ b/bash/bash_lib/core.sh
@@ -159,7 +159,7 @@ t() {
 
 # Papelera en vez de rm directo
 trash() {
-  _req thrash-put || {
+  _req trash-put || {
     printf 'Necesito trash-put (paquete trash-cli)\n' >&2
     return 1
   }


### PR DESCRIPTION
## Summary
- ensure the trash helper checks for the trash-put command instead of the misspelled thrash-put
- keep the error guidance pointing to the trash-cli package

## Testing
- not run (trash-put not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ffa6af4c2c832d9ca3ca51ccee6f91