### PR TITLE
Condicionar PATH de Composer al existir

### DIFF
--- a/bash/bashrc
+++ b/bash/bashrc
@@ -127,4 +127,6 @@ move_to_end "/nix/var/nix/profiles/default/bin"
 export PATH
 
 # PATH y extras ligeros
-export PATH=/home/acuervo/.config/composer/vendor/bin:${PATH}
+if [ -d "$HOME/.config/composer/vendor/bin" ]; then
+  PATH="$HOME/.config/composer/vendor/bin:$PATH"
+fi


### PR DESCRIPTION
## Summary
- add a guard before prepending the Composer vendor bin directory to PATH
- use the $HOME variable instead of a hardcoded username when updating PATH

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ffb0db7b74832db9fe75bda1ae3b85