### PR TITLE
Improve tmux network interface auto-detection

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -158,7 +158,7 @@ set -g pane-border-format " #P: #{pane_current_command} — #{b:pane_current_pat
 set -g display-panes-time 5000
 #set -g @catppuccin_window_status_format         " #[nobold]#I:#W "
 #set -g @catppuccin_window_status_current_format " #[bold]#I:#W "
-set -g @net_if "enp2s0"
+set -g @net_if ""
 
 ##### Status bar (indicadores nativos + Git + CPU + MEM + NET)
 set -g status on
@@ -181,7 +181,16 @@ set -g status-right "\
 #[fg=#f38ba8]#[bg=#f38ba8,fg=#1e1e2e]  #{?client_prefix,⌨  PREFIX,} #[bg=#1e1e2e,fg=#f38ba8]\
  #[fg=#94e2d5]#[bg=#94e2d5,fg=#1e1e2e] #{?pane_in_mode,󰆏 COPY, } #[bg=#1e1e2e,fg=#94e2d5]\
  #[fg=#cba6f7]#[bg=#cba6f7,fg=#1e1e2e] #(sh -lc 'cd \"#{pane_current_path}\" 2>/dev/null && git rev-parse --abbrev-ref HEAD 2>/dev/null || true') #[bg=#1e1e2e,fg=#cba6f7]\
- #[fg=#000000]#[bg=#000000,fg=#777777] #(sh -lc '[ -x ~/.tmux/scripts/status_pill.sh ] && IF_OVERRIDE='"'#{@net_if}'"' ~/.tmux/scripts/status_pill.sh || printf \"\"') #[bg=#1e1e2e,fg=#1e1e2e]"
+ #[fg=#000000]#[bg=#000000,fg=#777777] #(sh -lc '
+if [ -x ~/.tmux/scripts/status_pill.sh ]; then
+  IF_RAW="#{@net_if}"
+  if [ -z "$IF_RAW" ]; then
+    IF_RAW="$(~/.tmux/scripts/status_pill.sh --detect-ifaces)"
+  fi
+  IF_OVERRIDE="$IF_RAW" ~/.tmux/scripts/status_pill.sh
+else
+  printf ""
+fi') #[bg=#1e1e2e,fg=#1e1e2e]"
 
 
 setw -g window-status-format         " #[nobold]#I:#W "


### PR DESCRIPTION
## Summary
- allow the tmux status pill script to normalise override lists and expose an auto-detect helper
- add a detection-only mode so the script can report the best available interfaces when no override is provided
- update the tmux configuration to leave @net_if empty and resolve a default list at runtime using the script

## Testing
- bash -n tmux/tmux/scripts/status_pill.sh

------
https://chatgpt.com/codex/tasks/task_e_68ffb0dd3780832d97f64d2b293cf400