### PR TITLE
Add docker compose pull alias and prune helper

### DIFF
--- a/SHORTCUTS.md
+++ b/SHORTCUTS.md
@@ -343,6 +343,7 @@
 | `docps` | `bash/bash_lib/docker.sh` | Lista servicios activos con `docker compose ps`. |
 | `dlogs` | `bash/bash_lib/docker.sh` | Selecciona servicio con `fzf` y hace `logs -f` tail 200. |
 | `dsh` | `bash/bash_lib/docker.sh` | Abre shell interactiva (`bash`/`sh`) en servicio en ejecución. |
+| `dclean` | `bash/bash_lib/docker.sh` | Ejecuta `docker system prune` tras confirmación explícita. |
 | `fo` | `bash/bash_lib/nav.sh` | Busca archivos/dirs con `fd` + `fzf`, abre o `cd`. |
 | `cdf` | `bash/bash_lib/nav.sh` | Navega a directorios recientes vía `zoxide`. |
 | `take` | `bash/bash_lib/nav.sh` | `mkdir -p` + `cd` en una sola orden. |
@@ -424,7 +425,7 @@
 | `ls` | Si existe `eza`: `eza --group-directories-first --icons=auto --color=auto --sort newest -la`; si no, `ls --color=auto`. | Listado enriquecido. |
 | `ll` | `eza -lh --git ...` o `ls -alh --color=auto` | Listado detallado. |
 | `la` | `eza -a ...` o `ls -A --color=auto` | Incluye ocultos. |
-| `dc` / `dcb` / `dcu` / `dcud` / `dcd` / `dcr` | `docker compose` (varias subcomandos) | Atajos compose v2 (solo si docker existe). |
+| `dc` / `dcb` / `dcp` / `dcu` / `dcud` / `dcd` / `dcr` | `docker compose` (varias subcomandos) | Atajos compose v2 (solo si docker existe). |
 | `dcps` | `docker compose ps` | Lista servicios. |
 | `dps` | `docker ps -a --format "table ..."` | Tabla de contenedores. |
 | `dcl` / `dclf` / `dce` | Logs, logs -f y exec (compose). |

--- a/bash/bash_aliases
+++ b/bash/bash_aliases
@@ -30,6 +30,7 @@ fi
 if command -v docker >/dev/null 2>&1; then
   alias dc='docker compose'
   alias dcb='docker compose build'
+  alias dcp='docker compose pull'
   alias dcu='docker compose up'
   alias dcud='docker compose up -d'
   alias dcd='docker compose down'

--- a/bash/bash_lib/docker.sh
+++ b/bash/bash_lib/docker.sh
@@ -86,3 +86,15 @@ dsh() {
 
   _docker_compose exec "$svc" bash 2>/dev/null || _docker_compose exec "$svc" sh
 }
+
+# Limpiar recursos docker sin uso tras confirmación explícita
+dclean() {
+  _req docker || return 1
+
+  printf '%s' 'Esto ejecutará "docker system prune" y eliminará contenedores detenidos, imágenes dangling y cachés. ¿Continuar? [y/N] ' >&2
+  local ans
+  read -r ans
+  [ "$ans" = "y" ] || return 0
+
+  docker system prune "$@"
+}


### PR DESCRIPTION
## Summary
- add a `dcp` alias to run `docker compose pull`
- introduce a `dclean` helper that wraps `docker system prune` with confirmation
- document the new alias and helper in the shortcuts reference

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ffb0e419a4832da2505e68e44e94de