### PR TITLE
Add atuin initialization to bashrc

### DIFF
--- a/bash/bashrc
+++ b/bash/bashrc
@@ -86,6 +86,11 @@ if command -v starship >/dev/null 2>&1; then
   eval "$(starship init bash)"
 fi
 
+# - atuin (historial avanzado)
+if command -v atuin >/dev/null 2>&1; then
+  eval "$(atuin init bash)"
+fi
+
 # - fnm (gestor de versiones de node)
 if [ -z "${FNM_INITIALIZED:-}" ]; then
   if command -v fnm >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- add a conditional Atuin initialization hook to the Bash configuration so shells can load history sync when available

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ffb0e58184832d95e0681b308c2570