### PR TITLE
Improve bootstrap and rollback workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ bash ./scripts/bootstrap.sh --dry-run
 bash ./scripts/bootstrap.sh
 ```
 
-Acciones (modo `stow`, por defecto):
+Acciones principales:
 
-- Crea backup en `.backups/<TS>/` y manifest en `.manifests/<TS>.manifest`.
-- Enlaza explícitamente Bash (`bashrc`, `bash_profile`, `bash_aliases`, `bash_functions`, `bash_lib`), Git (`gitconfig`, `gitalias`, `git-hooks`), tmux (`tmux.conf`, `tmux/`), Vim (`vimrc`, `vim/`).
-- Stow de `config/{dunst,i3,kitty,lazygit,nvim,picom,polybar,rofi}` sobre `~/.config`. Personaliza con `--packages=kitty,polybar`.
-- Acepta `DOTFILES=/otra/ruta ./scripts/bootstrap.sh` para entornos compartidos.
+- Crea backups con timestamp en `.backups/<TS>/` (dentro del repo) y manifiesto en `.manifests/<TS>.manifest`.
+- Enlaza Bash (`bashrc`, `bash_profile`, `bash_aliases`, `bash_functions`, `bash_lib`), Git (`gitconfig`, `gitalias`, `git-hooks`), tmux (`tmux.conf`, `tmux/`) y Vim (`vimrc`, `vim/`) directamente sobre `$HOME`.
+- Genera enlaces simbólicos de `config/{atuin,blesh,dunst,i3,kitty,lazygit,mise,nvim,picom,polybar,rofi,yazi}` sobre `~/.config/<pkg>`.
+- Acepta `DOTFILES=/otra/ruta ./scripts/bootstrap.sh` para seleccionar el repo y `--dry-run` para validar sin modificar nada.
 
-Manifiesto (`.manifests/<TS>.manifest`) registra los symlinks aplicados (`LINK src -> dest`) y la lista de paquetes stoweados.
+El manifiesto (`.manifests/<TS>.manifest`) registra cada symlink aplicado (`LINK src -> dest`) para facilitar el rollback.
 
 ### Plan B (si no usas scripts)
 
@@ -84,10 +84,10 @@ done
 bash ./scripts/rollback.sh latest
 ```
 
-- Lee el último manifest, aplica `stow -D` sobre los paquetes listados y borra los symlinks registrados.
-- Restaura el backup (`rsync -a .backups/<TS>/ $HOME/`).
+- Detecta el backup más reciente en `.backups/` (o en `~/.dotfiles_backup_*` para versiones antiguas).
+- Restaura el contenido sobre `$HOME` usando `rsync -a` con `--backup-dir` para guardar los ficheros actuales en `~/.dotfiles_rollback_conflicts_*`.
 
-Rollback por timestamp:
+Rollback por timestamp (directorio dentro de `.backups/` o ruta absoluta):
 
 ```bash
 bash ./scripts/rollback.sh 20251020-120000

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,103 +1,193 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+usage() {
+        cat <<'USAGE'
+Uso: bootstrap.sh [opciones]
+
+Opciones:
+  -n, --dry-run        Muestra las acciones sin modificar nada.
+  -h, --help           Muestra esta ayuda.
+
+Variables de entorno:
+  DOTFILES             Ruta al repo (por defecto, carpeta raíz del script).
+USAGE
+}
+
+DRY_RUN=false
+USER_REPO=""
+
+while (($# > 0)); do
+        case "$1" in
+        -n | --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+        -h | --help)
+                usage
+                exit 0
+                ;;
+        --repo)
+                if (($# < 2)); then
+                        echo "[ERROR] --repo requiere una ruta" >&2
+                        exit 1
+                fi
+                USER_REPO="$2"
+                shift 2
+                ;;
+        *)
+                echo "[ERROR] Opción no reconocida: $1" >&2
+                usage >&2
+                exit 1
+                ;;
+        esac
+done
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [ -d "$SCRIPT_DIR/bash" ]; then
-	REPO_DIR="$SCRIPT_DIR"
-else
-	REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEFAULT_REPO="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_DIR="${USER_REPO:-${DOTFILES:-$DEFAULT_REPO}}"
+REPO_DIR="${REPO_DIR/#\~/$HOME}" # expandir ~ inicial
+
+if [[ ! -d "$REPO_DIR" ]]; then
+        echo "[ERROR] Repo no encontrado en: $REPO_DIR" >&2
+        exit 1
 fi
 
+TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
+BACKUP_BASE="$REPO_DIR/.backups"
+MANIFEST_DIR="$REPO_DIR/.manifests"
 BACKUP_DIR=""
+MANIFEST_FILE="$MANIFEST_DIR/$TIMESTAMP.manifest"
+MANIFEST_READY=false
+
+info() { printf '[INFO] %s\n' "$*"; }
+warn() { printf '[WARN] %s\n' "$*"; }
+action() {
+        local kind="$1"; shift
+        if $DRY_RUN; then
+                printf '[DRY-RUN][%s] %s\n' "$kind" "$*"
+        else
+                printf '[%s] %s\n' "$kind" "$*"
+        fi
+}
+
+run_cmd() {
+        if $DRY_RUN; then
+                return 0
+        fi
+        "$@"
+}
 
 ensure_backup_dir() {
-	if [ -z "$BACKUP_DIR" ]; then
-		BACKUP_DIR="$HOME/.dotfiles_backup_$(date +%Y%m%d_%H%M%S)"
-		mkdir -p "$BACKUP_DIR"
-		echo "[INFO] Creando directorio de backup en $BACKUP_DIR"
-	fi
+        if [[ -n "$BACKUP_DIR" ]]; then
+                return
+        fi
+        BACKUP_DIR="$BACKUP_BASE/$TIMESTAMP"
+        action "BACKUP" "Creando directorio en $BACKUP_DIR"
+        run_cmd mkdir -p "$BACKUP_DIR"
+}
+
+ensure_manifest_file() {
+        if $DRY_RUN || $MANIFEST_READY; then
+                return
+        fi
+        mkdir -p "$MANIFEST_DIR"
+        : >"$MANIFEST_FILE"
+        MANIFEST_READY=true
+}
+
+record_manifest() {
+        local line="$1"
+        if $DRY_RUN; then
+                return
+        fi
+        ensure_manifest_file
+        printf '%s\n' "$line" >>"$MANIFEST_FILE"
 }
 
 link_item() {
-	local rel_path="$1"
-	local target_rel="$2" # relativo a $HOME
-	local src="$REPO_DIR/$rel_path"
-	local dest="$HOME/$target_rel"
+        local rel_path="$1"
+        local target_rel="$2"
+        local src="$REPO_DIR/$rel_path"
+        local dest="$HOME/$target_rel"
 
-	if [ ! -e "$src" ] && [ ! -d "$src" ]; then
-		echo "[WARN] Origen no existe: $src (saltando)"
-		return 0
-	fi
+        if [[ ! -e "$src" && ! -d "$src" ]]; then
+                warn "Origen no existe: $src (saltando)"
+                return
+        fi
 
-	# Si ya es el symlink correcto, no hacemos nada
-	if [ -L "$dest" ] && [ "$(readlink "$dest")" = "$src" ]; then
-		echo "[OK]  $dest ya apunta a $src"
-		return 0
-	fi
+        if [[ -L "$dest" && "$(readlink "$dest")" == "$src" ]]; then
+                action "SKIP" "$dest ya apunta a $src"
+                return
+        fi
 
-	# Backup si existe algo en destino
-	if [ -e "$dest" ] || [ -L "$dest" ]; then
-		ensure_backup_dir
-		local backup_dest="$BACKUP_DIR/$target_rel"
-		mkdir -p "$(dirname "$backup_dest")"
-		echo "[INFO] Moviendo $dest a $backup_dest"
-		mv "$dest" "$backup_dest"
-	fi
+        if [[ -e "$dest" || -L "$dest" ]]; then
+                ensure_backup_dir
+                local backup_dest="$BACKUP_DIR/$target_rel"
+                action "MOVE" "Guardando $dest en $backup_dest"
+                run_cmd mkdir -p "$(dirname "$backup_dest")"
+                run_cmd mv "$dest" "$backup_dest"
+        fi
 
-	mkdir -p "$(dirname "$dest")"
-	echo "[LINK] $dest -> $src"
-	ln -s "$src" "$dest"
+        run_cmd mkdir -p "$(dirname "$dest")"
+        action "LINK" "$dest -> $src"
+        run_cmd ln -s "$src" "$dest"
+        record_manifest "LINK $src -> $dest"
 }
+
+HOME_ITEMS=(
+        "bash/bashrc:.bashrc"
+        "bash/bash_profile:.bash_profile"
+        "bash/profile:.profile"
+        "bash/xprofile:.xprofile"
+        "bash/bash_aliases:.bash_aliases"
+        "bash/bash_functions:.bash_functions"
+        "bash/bash_lib:.bash_lib"
+        "git/gitalias:.gitalias"
+        "git/gitconfig:.gitconfig"
+        "git/git-hooks:.git-hooks"
+        "tmux/tmux.conf:.tmux.conf"
+        "tmux/tmux:.tmux"
+        "vim/vimrc:.vimrc"
+        "vim/vim:.vim"
+)
+
+CONFIG_ITEMS=(atuin blesh dunst i3 kitty lazygit mise nvim picom polybar rofi yazi)
 
 main() {
-	echo "[INFO] Repo de dotfiles: $REPO_DIR"
-	echo "[INFO] Instalando symlinks en $HOME"
-	echo
+        info "Repo de dotfiles: $REPO_DIR"
+        if $DRY_RUN; then
+                info "Modo simulación activo (no se aplicarán cambios)"
+        fi
+        echo
 
-	# --- Bash ---
-	link_item "bash/bashrc" ".bashrc"
-	link_item "bash/bash_profile" ".bash_profile"
-	link_item "bash/profile" ".profile"
-	link_item "bash/xprofile" ".xprofile"
-	link_item "bash/bash_aliases" ".bash_aliases"
-	link_item "bash/bash_functions" ".bash_functions"
-	link_item "bash/bash_lib" ".bash_lib"
+        for entry in "${HOME_ITEMS[@]}"; do
+                IFS=":" read -r rel target <<<"$entry"
+                link_item "$rel" "$target"
+        done
 
-	# --- Config (~/.config/...) ---
-	link_item "config/atuin" ".config/atuin"
-	link_item "config/blesh" ".config/blesh"
-	link_item "config/dunst" ".config/dunst"
-	link_item "config/i3" ".config/i3"
-	link_item "config/kitty" ".config/kitty"
-	link_item "config/lazygit" ".config/lazygit"
-	link_item "config/mise" ".config/mise"
-	link_item "config/nvim" ".config/nvim"
-	link_item "config/picom" ".config/picom"
-	link_item "config/polybar" ".config/polybar"
-	link_item "config/rofi" ".config/rofi"
-	link_item "config/yazi" ".config/yazi"
+        for pkg in "${CONFIG_ITEMS[@]}"; do
+                link_item "config/$pkg" ".config/$pkg"
+        done
 
-	# --- Git ---
-	link_item "git/gitconfig" ".gitconfig"
-	link_item "git/gitalias" ".gitalias"
-	link_item "git/git-hooks" ".git-hooks"
+        echo
+        if [[ -n "$BACKUP_DIR" ]]; then
+                info "Copias guardadas en: $BACKUP_DIR"
+        elif $DRY_RUN; then
+                info "No se crearían backups (no hay colisiones detectadas)."
+        else
+                info "No fue necesario crear backups."
+        fi
 
-	# --- Tmux ---
-	link_item "tmux/tmux.conf" ".tmux.conf"
-	link_item "tmux/tmux" ".tmux"
+        if $DRY_RUN; then
+                info "Manifest simulado: $MANIFEST_FILE"
+        elif $MANIFEST_READY; then
+                info "Manifest generado: $MANIFEST_FILE"
+        else
+                info "No se generó manifest (sin enlaces nuevos)."
+        fi
 
-	# --- Vim ---
-	link_item "vim/vimrc" ".vimrc"
-	link_item "vim/vim" ".vim"
-	link_item "vim/vim-tmp" ".vim-tmp"
-
-	echo
-	echo "[INFO] Instalación de dotfiles completada."
-	if [ -n "$BACKUP_DIR" ]; then
-		echo "[INFO] Copias de seguridad en: $BACKUP_DIR"
-	else
-		echo "[INFO] No ha sido necesario crear copias de seguridad (no había nada que pisar)."
-	fi
+        info "Instalación de dotfiles completada."
 }
 
-main "$@"
+main


### PR DESCRIPTION
## Summary
- add a flaggable bootstrap flow that creates backups/manifests, honours DOTFILES and supports dry-run execution
- teach the rollback helper to discover backups in the repo, accept `latest` and keep protecting the current home via rsync backups
- refresh the README bootstrap/rollback section to document the new behaviour

## Testing
- bash -n scripts/bootstrap.sh
- bash -n scripts/rollback.sh


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691def27970c832d80cbceb81940d981)