### PR TITLE
Add manifest-driven rollback cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,10 @@ Preferimos [Conventional Commits](https://www.conventionalcommits.org/es/v1.0.0/
   ```
 - Navegación cruzada: `Ctrl+h/j/k/l` entre vim/tmux (plugin/vinculación).
 - Docker compose: `docps` y `dlogs` deben funcionar con v1/v2.
+- Pruebas manuales recomendadas:
+  - `bash ./scripts/bootstrap.sh` → verificar symlinks creados y manifest generado en `.manifests/<TS>.manifest`.
+  - Editar un dotfile enlazado (p.ej. añadir comentario en `~/.bashrc`) y ejecutar `bash ./scripts/rollback.sh --manifest .manifests/<TS>.manifest <TS>` para comprobar que los symlinks desaparecen y se restaura el backup.
+  - Repetir el rollback con un manifest inexistente para validar que el script avisa y no borra enlaces.
 
 ## Checklist de PR
 - [ ] Cambios mínimos y compatibles con Arch estable.

--- a/README-BOOTSTRAP.md
+++ b/README-BOOTSTRAP.md
@@ -1,7 +1,7 @@
 # README-BOOTSTRAP
 
 Guía práctica para desplegar estos **dotfiles** en Arch Linux (o derivadas) mediante `scripts/bootstrap.sh`.
-Incluye los paquetes recomendados, el flujo de symlinks/backup, validaciones y un plan B manual con `stow`/`ln -s`.
+Incluye los paquetes recomendados, el flujo de symlinks/backup/manifest, validaciones y un plan B manual con `stow`/`ln -s`.
 
 ## 1. Paquetes base (pacman)
 
@@ -32,7 +32,7 @@ cd dotfiles
 ## 3. Bootstrap automatizado
 
 El script enlaza Bash, Git, tmux, NeoVim/Vim, Kitty, i3, polybar, rofi, picom, dunst, lazygit, atuin, blesh, mise, yazi, etc.,
-creando copias de seguridad previas en `~/.dotfiles_backup_<TS>`.
+creando copias de seguridad previas en `<repo>/.backups/<TS>` y registrando cada symlink en `<repo>/.manifests/<TS>.manifest`.
 
 ```bash
 cd ~/dotfiles
@@ -69,7 +69,7 @@ done
 
 ## 5. Rollback
 
-Todos los backups siguen el patrón `~/.dotfiles_backup_YYYYmmdd_HHMMSS`. Para restaurar el último:
+Todos los backups siguen el patrón `<repo>/.backups/YYYYmmdd_HHMMSS` (o `~/.dotfiles_backup_*` en versiones antiguas). Para restaurar el último:
 
 ```bash
 bash ./scripts/rollback.sh
@@ -81,8 +81,9 @@ O bien pasa la ruta concreta del backup que quieras reaplicar:
 bash ./scripts/rollback.sh ~/.dotfiles_backup_20250101_120000
 ```
 
-`rollback.sh` usa `rsync` con `--backup-dir` para guardar en `~/.dotfiles_rollback_conflicts_<TS>` cualquier archivo actual que
-vaya a sobrescribir.
+`rollback.sh` intenta resolver el manifest `./.manifests/<TS>.manifest` para eliminar los symlinks creados por el bootstrap antes de restaurar. Si el manifest no existe (p.ej. backups muy antiguos), puedes pasarlo a mano con `--manifest /ruta/al/archivo`; de lo contrario tendrás que borrar los enlaces manualmente.
+
+`rollback.sh` usa `rsync` con `--backup-dir` para guardar en `~/.dotfiles_rollback_conflicts_<TS>` cualquier archivo actual que vaya a sobrescribir.
 
 ## 6. Plan B (sin script)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Repositorio de uso diario para **Arch Linux** orientado a productividad: i3 + tm
 ## Pila y highlights
 
 - **Bootstrap reproducible** mediante `scripts/bootstrap.sh` con backups timestamp en `.backups/<TS>` y manifiestos en `.manifests/<TS>.manifest`.
-- **Rollback automático**: `scripts/rollback.sh <timestamp|latest>` deshace symlinks y restaura backups.
+- **Rollback automático**: `scripts/rollback.sh <timestamp|latest>` elimina los symlinks listados en el manifest y luego restaura backups (con flag `--manifest` para apuntar a manifiestos antiguos).
 - **Librería Bash modular** (`bash/bash_lib/*.sh`) con helpers para git, docker, navegación y productividad (`cb`, `rgf`, `grt`, `fo`, `docps`, etc.).
 - **NeoVim** (≥0.11) con lazy.nvim, Mason v2, Treesitter, LSP/DAP, conform.nvim + nvim-lint, Overseer y tooling git/telescope.
 - **tmux** con prefix `Ctrl+s`, integración NeoVim (vim-tmux-navigator), TPM (resurrect, continuum, menus, fzf, extrakto) y scripts personalizados.
@@ -121,6 +121,7 @@ bash ./scripts/rollback.sh latest
 ```
 
 - Detecta el backup más reciente en `.backups/` (o en `~/.dotfiles_backup_*` para versiones antiguas).
+- Lee el manifest asociado (por defecto `./.manifests/<TS>.manifest`) y elimina los symlinks creados por el bootstrap para evitar que apunten al repo.
 - Restaura el contenido sobre `$HOME` usando `rsync -a` con `--backup-dir` para guardar los ficheros actuales en `~/.dotfiles_rollback_conflicts_*`.
 
 Rollback por timestamp (directorio dentro de `.backups/` o ruta absoluta):
@@ -129,8 +130,15 @@ Rollback por timestamp (directorio dentro de `.backups/` o ruta absoluta):
 bash ./scripts/rollback.sh 20251020-120000
 ```
 
-- Lee el manifest correspondiente, ejecuta `stow -D` y elimina symlinks listados.
+- Usa el manifest derivado del timestamp (`.manifests/<TS>.manifest`) o el indicado con `--manifest /ruta/al/archivo` para eliminar symlinks.
 - Restaura backup con `rsync -a .backups/<TS>/ $HOME/`.
+- Si no se encuentra manifest, el script avisa y no borra los enlaces, por lo que podrías tener que eliminarlos manualmente antes de aplicar el backup.
+
+Rollback apuntando a un manifest concreto (útil si el backup viene de otra ruta o el nombre no sigue el patrón de timestamp):
+
+```bash
+bash ./scripts/rollback.sh --manifest /ruta/a/.manifests/20251020_120000.manifest /ruta/al/backup
+```
 
 ---
 

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -3,12 +3,16 @@ set -euo pipefail
 
 usage() {
         cat <<'USAGE'
-Uso: rollback.sh [DIRECTORIO|latest]
+Uso: rollback.sh [opciones] [DIRECTORIO|latest]
 
 Sin argumentos o con "latest", restaura el backup más reciente.
 Puedes pasar un directorio absoluto o uno relativo a:
   - $DOTFILES/.backups
   - $HOME
+
+Opciones:
+  --manifest RUTA   Ruta al manifest a usar para limpiar symlinks (por defecto
+                    se intenta asociar el manifest por timestamp del backup).
 
 Variables de entorno:
   DOTFILES   Ruta al repo (por defecto, carpeta raíz del script).
@@ -25,9 +29,43 @@ if [[ ! -d "$REPO_DIR" ]]; then
         exit 1
 fi
 
-if [[ "${1-}" == "-h" || "${1-}" == "--help" ]]; then
-        usage
-        exit 0
+POSITIONAL=()
+MANIFEST_OVERRIDE=""
+
+while (($# > 0)); do
+        case "$1" in
+        -h | --help)
+                usage
+                exit 0
+                ;;
+        --manifest)
+                if (($# < 2)); then
+                        echo "[ERROR] --manifest requiere una ruta" >&2
+                        exit 1
+                fi
+                MANIFEST_OVERRIDE="$2"
+                shift 2
+                ;;
+        --)
+                shift
+                break
+                ;;
+        -*)
+                echo "[ERROR] Opción no reconocida: $1" >&2
+                usage >&2
+                exit 1
+                ;;
+        *)
+                POSITIONAL+=("$1")
+                shift
+                ;;
+        esac
+done
+
+if ((${#POSITIONAL[@]} > 1)); then
+        echo "[ERROR] Solo se admite un argumento de directorio." >&2
+        usage >&2
+        exit 1
 fi
 
 resolve_input_path() {
@@ -69,7 +107,8 @@ find_latest_backup() {
         printf '%s' "${candidates[-1]}"
 }
 
-SELECTED_DIR="$(resolve_input_path "${1-}")"
+SELECTED_INPUT="${POSITIONAL[0]-}"
+SELECTED_DIR="$(resolve_input_path "$SELECTED_INPUT")"
 if [[ -z "$SELECTED_DIR" ]]; then
         if ! latest="$(find_latest_backup)"; then
                 echo "[ERROR] No se encontraron directorios de backup en $REPO_DIR/.backups ni en $HOME" >&2
@@ -88,6 +127,68 @@ if ! command -v rsync >/dev/null 2>&1; then
         exit 1
 fi
 
+resolve_manifest_path() {
+        local override="$1"
+        local base_dir="$2"
+
+        if [[ -n "$override" ]]; then
+                local path="$override"
+                path="${path/#\~/$HOME}"
+                if [[ "$path" != /* ]]; then
+                        path="$REPO_DIR/$path"
+                fi
+                echo "$path"
+                return
+        fi
+
+        local backup_name
+        backup_name="$(basename "$base_dir")"
+        if [[ "$backup_name" =~ ^[0-9]{8}_[0-9]{6}$ ]]; then
+                echo "$REPO_DIR/.manifests/$backup_name.manifest"
+        else
+                echo ""
+        fi
+}
+
+remove_links_from_manifest() {
+        local manifest="$1"
+
+        if [[ -z "$manifest" ]]; then
+                echo "[WARN] No se pudo determinar manifest asociado; se omite limpieza de symlinks." >&2
+                return
+        fi
+
+        if [[ ! -f "$manifest" ]]; then
+                echo "[WARN] Manifest no encontrado: $manifest" >&2
+                echo "[WARN] Se omite la eliminación de symlinks; puede que el rollback deje enlaces antiguos." >&2
+                return
+        fi
+
+        echo "[INFO] Usando manifest: $manifest"
+        local pattern='^LINK[[:space:]]+(.*)[[:space:]]+->[[:space:]]+(.*)$'
+        while IFS= read -r line; do
+                [[ -z "$line" ]] && continue
+                if [[ $line =~ $pattern ]]; then
+                        local src="${BASH_REMATCH[1]}"
+                        local dest="${BASH_REMATCH[2]}"
+                        if [[ -L "$dest" ]]; then
+                                local current
+                                current="$(readlink "$dest")"
+                                if [[ "$current" == "$src" ]]; then
+                                        echo "[INFO] Eliminando symlink: $dest"
+                                        rm "$dest"
+                                else
+                                        echo "[WARN] $dest es un symlink pero apunta a '$current' (esperado '$src'); no se toca." >&2
+                                fi
+                        elif [[ -e "$dest" ]]; then
+                                echo "[WARN] $dest existe y no es symlink; se mantiene." >&2
+                        fi
+                fi
+        done <"$manifest"
+}
+
+MANIFEST_PATH="$(resolve_manifest_path "$MANIFEST_OVERRIDE" "$SELECTED_DIR")"
+
 echo "[INFO] Directorio de backup seleccionado: $SELECTED_DIR"
 echo "[INFO] Se restaurará su contenido sobre $HOME"
 echo "[INFO] Los ficheros actuales que se sobrescriban se guardarán en un directorio de conflictos."
@@ -104,6 +205,8 @@ esac
 
 CONFLICT_DIR="$HOME/.dotfiles_rollback_conflicts_$(date +%Y%m%d_%H%M%S)"
 mkdir -p "$CONFLICT_DIR"
+
+remove_links_from_manifest "$MANIFEST_PATH"
 
 echo "[INFO] Directorio de conflictos: $CONFLICT_DIR"
 echo "[INFO] Ejecutando rsync..."


### PR DESCRIPTION
## Summary
- parse rollback manifests to remove bootstrap symlinks before restoring backups and allow manually specifying a manifest path
- document the rollback flow, including manifest expectations and fallback behavior when missing
- add manual testing guidance for bootstrap/edit/rollback scenarios

## Testing
- bash -n scripts/rollback.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e120f94d8832d9c2ca098b4a105c2)