### PR TITLE
Document tmux net interface controls

### DIFF
--- a/bash/bash_lib/core.sh
+++ b/bash/bash_lib/core.sh
@@ -192,6 +192,22 @@ rgf() {
 # @cmd t  Crear/adjuntar sesión tmux
 t() {
   _req tmux || return 1
+
+  if [ "${1:-}" = "net-if" ]; then
+    shift
+    local value="$*"
+
+    if [ $# -eq 0 ]; then
+      tmux set -g @net_if ""
+      printf 'Limpiado @net_if; la pastilla de red autodetectará interfaces activas.\n' >&2
+    else
+      tmux set -g @net_if "$value"
+      printf 'Establecido tmux @net_if -> %s\n' "$value" >&2
+    fi
+
+    return 0
+  fi
+
   local name="${1:-main}"
 
   if tmux has-session -t "$name" 2>/dev/null; then

--- a/tmux/TMUX-CHEATSHEET.md
+++ b/tmux/TMUX-CHEATSHEET.md
@@ -115,3 +115,10 @@
 - **Árbol**: `choose-tree -Zw`  |  **Prompt**: `command-prompt`
 
 > Nota: todos los comandos son **nativos** de tmux. Revisa `man tmux` para detalles finos (flags o cambios entre versiones).
+
+## 13) Indicador de red (`@net_if`, `IF_OVERRIDE`, `--detect-ifaces`)
+- La pastilla de red (`tmux/scripts/status_pill.sh`) usa la lista en `@net_if` (o la variable `IF_OVERRIDE` si la ejecutas a mano) para calcular RX/TX y estado E/WiFi.
+- Si `@net_if` está vacío el script llama internamente a `--detect-ifaces`, que autodetecta interfaces `UP` evitando `lo`, `docker*`, `veth*`, etc. (fallback por defecto y seguro).
+- Para fijar orden o filtrar interfaces en caliente: `t net-if eth0 wlan0` (acepta espacios/comas/`;`; limpia con `t net-if` para volver a autodetección).
+- Para persistir en tu máquina añade en `~/.tmux.conf.local`: `set -g @net_if "eth0 wlan0"` (o elimínalo/deja vacío para autodetectar).
+- Puedes ver qué detectaría el script fuera de tmux con `~/.tmux/scripts/status_pill.sh --detect-ifaces`.

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -164,6 +164,9 @@ set -g status-left "\
 #[fg=#f9e2af]#[bg=#f9e2af,fg=#1e1e2e] #(bash -lc '[ -x ~/.tmux/scripts/shorten_path.sh ] && ~/.tmux/scripts/shorten_path.sh \"#{pane_current_path}\"  || printf \"%.50s\" \"#{pane_current_path}\"') #[bg=#1e1e2e,fg=#f9e2af]"
 
 # Status right: PREFIX, COPY, rama git, pill de red
+# - @net_if vacío => autodetección de interfaces activas (fallback seguro por defecto)
+# - Si defines @net_if en ~/.tmux.conf.local o con "t net-if" se usará ese orden
+set -g @net_if ""
 set -g status-right-length 200
 set -g status-right "\
 #[fg=#f38ba8]#[bg=#f38ba8,fg=#1e1e2e]  #{?client_prefix,⌨  PREFIX,} #[bg=#1e1e2e,fg=#f38ba8]\


### PR DESCRIPTION
## Summary
- add `t net-if` helper to set or clear tmux's `@net_if` list from the shell
- document network interface overrides, autodetection, and persistence in the tmux cheatsheet
- explicitly default `@net_if` to an empty value so the status pill safely autodetects interfaces

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e12342940832dbbb6135d9eceeb2a)